### PR TITLE
Pin `nixpkgs` and drop use of `fetchgitPrivate` for `proto3-suite`.

### DIFF
--- a/nixpkgs.json
+++ b/nixpkgs.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://github.com/NixOS/nixpkgs.git",
+  "rev": "7ae9da426924537755ce9164fd5b5f81ce16a1c3",
+  "date": "2017-01-31T10:35:58-06:00",
+  "sha256": "1fcvc066c270dd2yfir8cpj0gcslsbvw7grnk2fayb06rkppjxrf"
+}

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,21 @@
+let
+  # NOTE: This is the only non-deterministic part of our system since we need a
+  # a starting point in order to be able to fetch the pinned `nixpkgs`.  From
+  # that point forward our build is deterministic and pinned
+  #
+  # We only use this for the `fetchFromGitHub` utility so as long as that
+  # remains stable then we shouldn't have migration issues.
+  inherit (import <nixpkgs> { }) fetchFromGitHub;
+
+  # In order to update `nixpkgs.json` to a specific revision, run:
+  #
+  # ```bash
+  # $ nix-prefetch-git https://github.com/NixOS/nixpkgs.git "${REVISION}" > nixpkgs.json
+  # ```
+  nixpkgs = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+in
+  fetchFromGitHub {
+    owner = "NixOS";
+    repo  = "nixpkgs";
+    inherit (nixpkgs) rev sha256;
+  }

--- a/release.nix
+++ b/release.nix
@@ -46,15 +46,20 @@
 # You can also add private Git dependencies in the same way, except supplying
 # the `git` URL to clone:
 #
-#     $ cabal2nix git@github.mv.awakenetworks.net:awakenetworks/${package-name}.git > ./nix/${package-name}.nix
+#     $ cabal2nix <your private git url>/${package-name}.git > ./nix/${package-name}.nix
 #
-# `cabal2nix` also takes an optional `--revision` flag if you want to pick a
-# revision other than the latest one to depend on.
+# ...but also be sure to supply `fetchgit = pkgs.fetchgitPrivate` in the
+# `haskellPackagesNew.callPackage` invocation for your private package.
 #
-# If you want to test a local source checkout of a dependency, then run:
+# Note that `cabal2nix` also takes an optional `--revision` flag if you want to
+# pick a revision other than the latest to depend on.
+#
+# Finally, if you want to test a local source checkout of a dependency, then
+# run:
 #
 #     $ cabal2nix path/to/dependency/repo > nix/${package-name}.nix
 let
+  nixpkgs = import ./nixpkgs.nix;
   config = {
     packageOverrides = pkgs: rec {
       cython = pkgs.buildPythonPackage rec {
@@ -265,9 +270,9 @@ let
 in
 
 let
-   linuxPkgs = import <nixpkgs> { inherit config; system = "x86_64-linux" ; };
-  darwinPkgs = import <nixpkgs> { inherit config; system = "x86_64-darwin"; };
-        pkgs = import <nixpkgs> { inherit config; };
+   linuxPkgs = import nixpkgs { inherit config; system = "x86_64-linux" ; };
+  darwinPkgs = import nixpkgs { inherit config; system = "x86_64-darwin"; };
+        pkgs = import nixpkgs { inherit config; };
 
 in
   { grpc-haskell-linux  =  linuxPkgs.haskellPackages.grpc-haskell;

--- a/release.nix
+++ b/release.nix
@@ -175,9 +175,7 @@ let
 
           proto3-suite =
             pkgs.haskell.lib.dontCheck
-              (haskellPackagesNew.callPackage ./nix/proto3-suite.nix {
-                fetchgit = pkgs.fetchgitPrivate;
-              });
+              (haskellPackagesNew.callPackage ./nix/proto3-suite.nix {});
 
           grpc-haskell-no-tests =
             pkgs.haskell.lib.overrideCabal


### PR DESCRIPTION
## Description

* `nixpkgs` is now pinned to `7ae9da426924537755ce9164fd5b5f81ce16a1c3`
* `fetchgitPrivate` is no longer used for slurping in `proto3-suite`
* minor documentation tweaks