### PR TITLE
Update `nix-shell` env and update `tasty-quickcheck` dep

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,8 @@
 { mkDerivation, async, base, bytestring, c2hs, clock, containers
 , grpc, managed, optparse-generic, pipes, proto3-suite, proto3-wire
-, QuickCheck, random, safe, sorted-list, stdenv, stm
-, system-filepath, tasty, tasty-hunit, tasty-quickcheck, text, time
-, transformers, turtle, unix, vector
+, QuickCheck, safe, sorted-list, stdenv, stm, system-filepath
+, tasty, tasty-hunit, tasty-quickcheck, text, time, transformers
+, turtle, unix, vector
 }:
 mkDerivation {
   pname = "grpc-haskell";
@@ -12,21 +12,21 @@ mkDerivation {
   isExecutable = true;
   libraryHaskellDepends = [
     async base bytestring clock containers managed pipes proto3-suite
-    proto3-wire safe sorted-list stm tasty tasty-hunit transformers
-    vector
+    proto3-wire safe sorted-list stm tasty tasty-hunit tasty-quickcheck
+    transformers vector
   ];
   librarySystemDepends = [ grpc ];
   libraryToolDepends = [ c2hs ];
   executableHaskellDepends = [
     async base bytestring containers optparse-generic proto3-suite
-    proto3-wire random system-filepath text transformers turtle vector
+    proto3-wire system-filepath text transformers turtle
   ];
   testHaskellDepends = [
     async base bytestring clock containers managed pipes proto3-suite
     QuickCheck safe tasty tasty-hunit tasty-quickcheck text time
     transformers turtle unix
   ];
-  homepage = "https://github.mv.awakenetworks.net/awakenetworks/gRPC-haskell";
+  homepage = "https://github.com/awakenetworks/gRPC-haskell";
   description = "Haskell implementation of gRPC layered on shared C library";
   license = stdenv.lib.licenses.asl20;
 }

--- a/grpc-haskell.cabal
+++ b/grpc-haskell.cabal
@@ -37,7 +37,7 @@ library
     , async ==2.1.*
     , tasty >= 0.11 && <0.12
     , tasty-hunit >= 0.9 && <0.10
-    , tasty-quickcheck
+    , tasty-quickcheck >= 0.8.4 && < 0.9
     , safe ==0.3.*
     , vector
     , sorted-list >=0.1.6.1 && <=0.3
@@ -249,7 +249,7 @@ test-suite test
     , async
     , tasty >= 0.11 && <0.12
     , tasty-hunit >= 0.9 && <0.10
-    , tasty-quickcheck
+    , tasty-quickcheck >= 0.8.4 && < 0.9
     , containers ==0.5.*
     , managed >= 1.0.0 && < 1.1
     , pipes >=4.1 && <=4.4

--- a/grpc-haskell.cabal
+++ b/grpc-haskell.cabal
@@ -37,6 +37,7 @@ library
     , async ==2.1.*
     , tasty >= 0.11 && <0.12
     , tasty-hunit >= 0.9 && <0.10
+    , tasty-quickcheck
     , safe ==0.3.*
     , vector
     , sorted-list >=0.1.6.1 && <=0.3
@@ -248,7 +249,7 @@ test-suite test
     , async
     , tasty >= 0.11 && <0.12
     , tasty-hunit >= 0.9 && <0.10
-    , tasty-quickcheck ==0.8.*
+    , tasty-quickcheck
     , containers ==0.5.*
     , managed >= 1.0.0 && < 1.1
     , pipes >=4.1 && <=4.4

--- a/release.nix
+++ b/release.nix
@@ -193,7 +193,7 @@ let
                     export DYLD_LIBRARY_PATH=${grpc}/lib''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH
                   '';
 
-                shellHook = ''
+                shellHook = (oldDerivation.shellHook or "") + ''
                   export DYLD_LIBRARY_PATH=${grpc}/lib''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH
                 '';
 
@@ -262,7 +262,7 @@ let
                       --prefix DYLD_LIBRARY_PATH : ${grpc}/lib
                   '';
 
-                  shellHook = ''
+                  shellHook = (oldDerivation.shellHook or "") + ''
                     export DYLD_LIBRARY_PATH=${grpc}/lib''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH
                     # This lets us use our custom ghc and python environments in the shell.
                     export PATH=${stack}/bin:${ghc}/bin:${python}/bin''${PATH:+:}$PATH

--- a/release.nix
+++ b/release.nix
@@ -192,6 +192,11 @@ let
                   pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
                     export DYLD_LIBRARY_PATH=${grpc}/lib''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH
                   '';
+
+                shellHook = ''
+                  export DYLD_LIBRARY_PATH=${grpc}/lib''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH
+                '';
+
               });
 
           grpc-haskell =
@@ -278,10 +283,11 @@ let
         pkgs = import nixpkgs { inherit config; };
 
 in
-  { grpc-haskell-linux  =  linuxPkgs.haskellPackages.grpc-haskell;
-    grpc-haskell-darwin = darwinPkgs.haskellPackages.grpc-haskell;
-    grpc-haskell        =       pkgs.haskellPackages.grpc-haskell;
-    grpc-linux          =  linuxPkgs.grpc;
-    grpc-darwin         = darwinPkgs.grpc;
-    grpc                =       pkgs.grpc;
+  { grpc-haskell-linux    =  linuxPkgs.haskellPackages.grpc-haskell;
+    grpc-haskell-darwin   = darwinPkgs.haskellPackages.grpc-haskell;
+    grpc-haskell          =       pkgs.haskellPackages.grpc-haskell;
+    grpc-haskell-no-tests = pkgs.haskellPackages.grpc-haskell-no-tests;
+    grpc-linux            =  linuxPkgs.grpc;
+    grpc-darwin           = darwinPkgs.grpc;
+    grpc                  =       pkgs.grpc;
   }


### PR DESCRIPTION
This PR adds a useful `shell-hook` to the `grpc-haskell-no-tests` attribute, and exposes that attribute at the toplevel, and makes the `tasty-quickcheck` packages available in testing environments. This is useful for debugging tests.