### PR TITLE
Update `release.nix` instructions.  Fixes #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ used to give you a development environment where you can use the `cabal` and
 
 ```bash
 $ nix-shell release-nix -A grpc-haskell.env
-[nix-shell]$ cabal configure --with-gcc=clang --enable-tests && cabal build && cabal test
+[nix-shell]$ cabal configure --enable-tests && cabal build && cabal test
 ```
 
 ```bash

--- a/release.nix
+++ b/release.nix
@@ -3,7 +3,7 @@
 #     $ # Consider adding the following command to your `~/.profile`
 #     $ NIX_PATH="${NIX_PATH}:ssh-config-file=${HOME}/.ssh/config:ssh-auth-sock=${SSH_AUTH_SOCK}"
 #     $ nix-shell -A grpc-haskell.env release.nix
-#     [nix-shell]$ cabal configure --with-gcc=clang --enable-tests && cabal build && cabal test
+#     [nix-shell]$ cabal configure --enable-tests && cabal build && cabal test
 #
 # This will open up a Nix shell where all of your Haskell tools will work like
 # normal, except that all dependencies (including C libraries) are managed by


### PR DESCRIPTION
We no longer require the `--with-gcc=clang` flag and it can cause
failed builds such as the one described in #19.  I tested that the
`cabal` workflow works on OS X and NixOS without this flag